### PR TITLE
Update finding GDAL and PROJ data paths for Ubuntu 24.04

### DIFF
--- a/hyo2/abc2/lib/gdal_aux.py
+++ b/hyo2/abc2/lib/gdal_aux.py
@@ -165,7 +165,7 @@ class GdalAux:
         candidate_gdal_data_paths.append(os.path.join(PkgHelper.python_path(), 'share', 'gdal'))
 
         try:
-            candidate_gdal_data_paths.append(subprocess.run(['gdal-config', '--datadir'], capture_output=True, text=True).stdout.strip())
+            candidate_gdal_data_paths.append(subprocess.run(['gdal-config', '--datadir'], capture_output=True, text=True).stdout.strip()) # nosec
         except Exception as e:
             logger.warning("%s" % e)
 
@@ -196,7 +196,7 @@ class GdalAux:
             if verbose:
                 logger.debug("already set PROJ_LIB = %s" % os.environ['PROJ_LIB'])
             return
-        
+
         try:
             proj_path = pyproj.datadir.get_data_dir()
             if verbose:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import codecs
 import os
 import re
+import subprocess
 
 from setuptools import setup, find_packages
 
@@ -26,6 +27,11 @@ def find_version(*file_paths):
 
     raise RuntimeError("Unable to find version string.")
 
+gdal = 'gdal'
+try:
+    gdal='gdal=='+subprocess.run(['gdal-config', '--version'], capture_output=True, text=True).stdout.strip()
+except Exception:
+    pass
 
 # ------------------------------------------------------------------
 #                          POPULATE SETUP
@@ -61,7 +67,7 @@ setup(
     ],
     install_requires=[
         "appdirs",
-        "gdal",
+        gdal,
         "matplotlib",
         "numpy",
         "psutil",


### PR DESCRIPTION
While attemting to run sound_speed_manager on Ubuntu 24.04 in standalone mode in a python virtual environment, the correct data paths for GDAL and PROJ were not getting configured. This fixes it on my system.